### PR TITLE
修复bug：关闭上网功能以适配README

### DIFF
--- a/main.c
+++ b/main.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 
 int surf_internet() {
-  return 0;
+  return 1;
 }
 
 int main() {


### PR DESCRIPTION
当前梦弘浏览器有一个显著的bug，就是README里明明说了不支持上网功能，但是实际提供了上网功能。

本着我们民族软件不能欺骗广大群众的态度，我来修复这个bug，正式关闭上网功能，以言行一致，知行合一